### PR TITLE
StatementFactory::createForExpectationFailure() does not need assertion argument

### DIFF
--- a/src/Factory/Model/NewStepFactory.php
+++ b/src/Factory/Model/NewStepFactory.php
@@ -117,8 +117,8 @@ readonly class NewStepFactory
             }
         }
 
-        if ($failedStatement instanceof AssertionInterface && $expectationFailure instanceof ExpectationFailure) {
-            $statement = $this->statementFactory->createForExpectationFailure($failedStatement, $expectationFailure);
+        if ($expectationFailure instanceof ExpectationFailure) {
+            $statement = $this->statementFactory->createForExpectationFailure($expectationFailure);
 
             if ($statement instanceof StatementInterface) {
                 $statements[] = $statement;

--- a/src/Factory/Model/Statement/StatementFactory.php
+++ b/src/Factory/Model/Statement/StatementFactory.php
@@ -48,10 +48,8 @@ class StatementFactory
         );
     }
 
-    public function createForExpectationFailure(
-        AssertionInterface $assertion,
-        ExpectationFailure $expectationFailure,
-    ): ?StatementInterface {
+    public function createForExpectationFailure(ExpectationFailure $expectationFailure): ?StatementInterface
+    {
         $expectedValue = $expectationFailure->expected;
         $examinedValue = $expectationFailure->examined;
 
@@ -63,13 +61,17 @@ class StatementFactory
             $examinedValue = $examinedValue ? 'true' : 'false';
         }
 
-        $failureSummary = $this->assertionFailureSummaryFactory->create($assertion, $expectedValue, $examinedValue);
+        $failureSummary = $this->assertionFailureSummaryFactory->create(
+            $expectationFailure->assertion,
+            $expectedValue,
+            $examinedValue
+        );
 
         if ($failureSummary instanceof AssertionFailureSummaryInterface) {
             return new FailedAssertionStatement(
-                $assertion->getSource(),
+                $expectationFailure->assertion->getSource(),
                 $failureSummary,
-                $this->transformationFactory->createTransformations($assertion)
+                $this->transformationFactory->createTransformations($expectationFailure->assertion)
             );
         }
 


### PR DESCRIPTION
Fixes #352